### PR TITLE
python3 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 all: cec.so
 
+PYTHON?=python
+
 ARCH:=$(shell uname -m)
 SYS:=$(shell uname -s | tr '[:upper:]' '[:lower:]')
-PY_VER:=$(shell python -c 'import sys; print "%d.%d"%(sys.version_info.major, sys.version_info.minor);')
+PY_VER:=$(shell $(PYTHON) -c 'import sys; print("%d.%d"%(sys.version_info.major, sys.version_info.minor));')
 
 BUILD_DIR:=build/lib.$(SYS)-$(ARCH)-$(PY_VER)
 
@@ -10,7 +12,7 @@ cec.so: $(BUILD_DIR)/cec.so
 	cp $< $@
 
 $(BUILD_DIR)/cec.so: cec.cpp setup.py device.h device.cpp
-	python setup.py build
+	$(PYTHON) setup.py build
 
 test: all
 	./test.py

--- a/cec.cpp
+++ b/cec.cpp
@@ -408,8 +408,13 @@ static PyObject * set_stream_path(PyObject * self, PyObject * args) {
 
    if( PyArg_ParseTuple(args, "O:set_stream_path", &arg) ) {
       Py_INCREF(arg);
+#if PY_MAJOR_VERSION >= 3
+      if(PyLong_Check(arg)) {
+         long arg_l = PyLong_AsLong(arg);
+#else
       if(PyInt_Check(arg)) {
          long arg_l = PyInt_AsLong(arg);
+#endif
          Py_DECREF(arg);
          if( arg_l < 0 || arg_l > 15 ) {
             PyErr_SetString(PyExc_ValueError, "Logical address must be between 0 and 15");
@@ -417,8 +422,13 @@ static PyObject * set_stream_path(PyObject * self, PyObject * args) {
          } else {
             RETURN_BOOL(CEC_adapter->SetStreamPath((cec_logical_address)arg_l));
          }
+#if PY_MAJOR_VERSION >= 3
+      } else if(PyUnicode_Check(arg)) {
+         char * arg_s = PyUnicode_AsUTF8(arg);
+#else
       } else if(PyString_Check(arg)) {
          char * arg_s = PyString_AsString(arg);
+#endif
          if( arg_s ) {
             int pa = parse_physical_addr(arg_s);
             Py_DECREF(arg);
@@ -677,7 +687,31 @@ void activated_cb(void * self, const cec_logical_address logical_address,
    return;
 }
 
+#if PY_MAJOR_VERSION >= 3
+static struct PyModuleDef moduledef = {
+   PyModuleDef_HEAD_INIT,
+   "cec",
+   NULL,
+   -1,
+   CecMethods,
+   NULL,
+   NULL,
+   NULL,
+   NULL
+};
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+#define INITERROR return NULL
+#else
+#define INITERROR return
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+PyMODINIT_FUNC PyInit_cec(void) {
+#else
 PyMODINIT_FUNC initcec(void) {
+#endif
    // Make sure threads are enabled in the python interpreter
    // this also acquires the global interpreter lock
    PyEval_InitThreads();
@@ -732,7 +766,7 @@ PyMODINIT_FUNC initcec(void) {
 
    if( !CEC_adapter ) {
       PyErr_SetString(PyExc_IOError, "Failed to initialize libcec");
-      return;
+      INITERROR;
    }
 
 #if CEC_LIB_VERSION_MAJOR > 1 || ( CEC_LIB_VERSION_MAJOR == 1 && CEC_LIB_VERSION_MINOR >= 8 )
@@ -742,11 +776,15 @@ PyMODINIT_FUNC initcec(void) {
    // set up python module
    PyTypeObject * dev = DeviceTypeInit(CEC_adapter);
    Device = (PyObject*)dev;
-   if(PyType_Ready(dev) < 0 ) return;
+   if(PyType_Ready(dev) < 0 ) INITERROR;
 
+#if PY_MAJOR_VERSION >= 3
+   PyObject * m = PyModule_Create(&moduledef);
+#else
    PyObject * m = Py_InitModule("cec", CecMethods);
+#endif
 
-   if( m == NULL ) return;
+   if( m == NULL ) INITERROR;
 
    Py_INCREF(dev);
    PyModule_AddObject(m, "Device", (PyObject*)dev);
@@ -785,4 +823,8 @@ PyMODINIT_FUNC initcec(void) {
    // this should help debugging by exposing which version was detected and
    // which adapter detection API was used at compile time
    PyModule_AddIntMacro(m, HAVE_CEC_ADAPTER_DESCRIPTOR);
+
+#if PY_MAJOR_VERSION >= 3
+   return m;
+#endif
 }

--- a/device.cpp
+++ b/device.cpp
@@ -282,7 +282,7 @@ static void Device_dealloc(Device * self) {
    Py_DECREF(self->cecVersion);
    Py_DECREF(self->osdName);
    Py_DECREF(self->lang);
-   self->ob_type->tp_free((PyObject*)self);
+   Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
 static PyObject * Device_str(Device * self) {
@@ -312,8 +312,7 @@ static PyMethodDef Device_methods[] = {
 };
 
 static PyTypeObject DeviceType = {
-   PyObject_HEAD_INIT(NULL)
-   0,                         /*ob_size*/
+   PyVarObject_HEAD_INIT(NULL, 0)
    "cec.Device",              /*tp_name*/
    sizeof(Device),            /*tp_basicsize*/
    0,                         /*tp_itemsize*/

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,9 @@ if "CFLAGS" in cfg_vars:
     cfg_vars["CFLAGS"] = cfg_vars["CFLAGS"].replace("-Wstrict-prototypes", "")
 if "OPT" in cfg_vars:
     cfg_vars["OPT"] = cfg_vars["OPT"].replace("-Wstrict-prototypes", "")
+# Do not append SOABI to extension filename
+if "EXT_SUFFIX" in cfg_vars:
+    cfg_vars["EXT_SUFFIX"] = ".so"
 
 python_cec = Extension('cec', sources = [ 'cec.cpp', 'device.cpp' ], 
                         include_dirs=['include'],


### PR DESCRIPTION
If your python3 binary is called `python3`, you can use the following to build with python3:
```
make PYTHON=python3
```
Default python binary is `python`.