### PR TITLE
Some more fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ cec.add_callback(handler, events)
 # the list of events is specified as a bitmask of the possible events:
 cec.EVENT_LOG
 cec.EVENT_KEYPRESS
-cec.EVENT_COMMAND # not implemented yet
+cec.EVENT_COMMAND
 cec.EVENT_CONFIG_CHANGE # not implemented yet
 cec.EVENT_ALERT
 cec.EVENT_MENU_CHANGED

--- a/cec.cpp
+++ b/cec.cpp
@@ -670,14 +670,17 @@ int log_cb(void * self, const cec_log_message message) {
    long int time = message.time;
    const char* msg = message.message;
 #endif
-   PyObject * args = Py_BuildValue("(iils)", EVENT_LOG, 
+   // decode message ignoring invalid characters
+   PyObject * umsg = PyUnicode_DecodeASCII(msg, strlen(msg), "ignore");
+   PyObject * args = Py_BuildValue("(iilO)", EVENT_LOG,
          level,
          time,
-         msg);
+         umsg);
    if( args ) {
       trigger_event(EVENT_LOG, args);
       Py_DECREF(args);
    }
+   Py_XDECREF(umsg);
    PyGILState_Release(gstate);
 #if CEC_LIB_VERSION_MAJOR >= 4
    return;

--- a/cec.cpp
+++ b/cec.cpp
@@ -639,8 +639,10 @@ int log_cb(void * self, const cec_log_message message) {
          level,
          time,
          msg);
-   trigger_event(EVENT_LOG, args);
-   Py_DECREF(args);
+   if( args ) {
+      trigger_event(EVENT_LOG, args);
+      Py_DECREF(args);
+   }
    PyGILState_Release(gstate);
 #if CEC_LIB_VERSION_MAJOR >= 4
    return;
@@ -667,8 +669,10 @@ int keypress_cb(void * self, const cec_keypress key) {
    PyObject * args = Py_BuildValue("(iBI)", EVENT_KEYPRESS,
          keycode,
          duration);
-   trigger_event(EVENT_KEYPRESS, args);
-   Py_DECREF(args);
+   if( args ) {
+      trigger_event(EVENT_KEYPRESS, args);
+      Py_DECREF(args);
+   }
    PyGILState_Release(gstate);
 #if CEC_LIB_VERSION_MAJOR >= 4
    return;
@@ -707,8 +711,10 @@ int command_cb(void * self, const cec_command command) {
    const cec_command * cmd = &command;
 #endif
    PyObject * args = Py_BuildValue("(iO&)", EVENT_COMMAND, convert_cmd, cmd);
-   trigger_event(EVENT_COMMAND, args);
-   Py_DECREF(args);
+   if( args ) {
+      trigger_event(EVENT_COMMAND, args);
+      Py_DECREF(args);
+   }
    PyGILState_Release(gstate);
 #if CEC_LIB_VERSION_MAJOR >= 4
    return;
@@ -732,9 +738,11 @@ int config_cb(void * self, const libcec_configuration) {
    //  this will probably be _lots_ of work and should probably wait until
    //  a later release, or when it becomes necessary.
    PyObject * args = Py_BuildValue("(i)", EVENT_CONFIG_CHANGE);
-   // don't bother triggering an event until we can actually pass arguments
-   //trigger_event(EVENT_CONFIG_CHANGE, args);
-   Py_DECREF(args);
+   if( args ) {
+      // don't bother triggering an event until we can actually pass arguments
+      //trigger_event(EVENT_CONFIG_CHANGE, args);
+      Py_DECREF(args);
+   }
    PyGILState_Release(gstate);
 #if CEC_LIB_VERSION_MAJOR >= 4
    return;
@@ -758,8 +766,10 @@ int alert_cb(void * self, const libcec_alert alert, const libcec_parameter p) {
       Py_INCREF(param);
    }
    PyObject * args = Py_BuildValue("(iiN)", EVENT_ALERT, alert, param);
-   trigger_event(EVENT_ALERT, args);
-   Py_DECREF(args);
+   if( args ) {
+      trigger_event(EVENT_ALERT, args);
+      Py_DECREF(args);
+   }
    PyGILState_Release(gstate);
 #if CEC_LIB_VERSION_MAJOR >= 4
    return;
@@ -773,8 +783,10 @@ int menu_cb(void * self, const cec_menu_state menu) {
    PyGILState_STATE gstate;
    gstate = PyGILState_Ensure();
    PyObject * args = Py_BuildValue("(ii)", EVENT_MENU_CHANGED, menu);
-   trigger_event(EVENT_MENU_CHANGED, args);
-   Py_DECREF(args);
+   if( args ) {
+      trigger_event(EVENT_MENU_CHANGED, args);
+      Py_DECREF(args);
+   }
    PyGILState_Release(gstate);
    return 1;
 }
@@ -787,8 +799,10 @@ void activated_cb(void * self, const cec_logical_address logical_address,
    PyObject * active = (state == 1) ? Py_True : Py_False;
    PyObject * args = Py_BuildValue("(iOi)", EVENT_ACTIVATED, active,
       logical_address);
-   trigger_event(EVENT_ACTIVATED, args);
-   Py_DECREF(args);
+   if( args ) {
+      trigger_event(EVENT_ACTIVATED, args);
+      Py_DECREF(args);
+   }
    PyGILState_Release(gstate);
    return;
 }

--- a/cec.cpp
+++ b/cec.cpp
@@ -286,16 +286,12 @@ static PyObject * list_devices(PyObject * self, PyObject * args) {
    return result;
 }
 
-class Callback {
+struct Callback {
    public:
       long int event;
       PyObject * cb;
 
       Callback(long int e, PyObject * c) : event(e), cb(c) {
-         Py_INCREF(cb);
-      }
-      ~Callback() {
-         Py_DECREF(cb);
       }
 };
 
@@ -319,6 +315,7 @@ static PyObject * add_callback(PyObject * self, PyObject * args) {
          return NULL;
       }
 
+      Py_INCREF(callback);
       Callback new_cb(events, callback);
 
       debug("Adding callback for event %ld\n", events);
@@ -344,6 +341,7 @@ static PyObject * remove_callback(PyObject * self, PyObject * args) {
            if( itr->event == 0 ) {
               // if this callback has no events, remove it
               itr = callbacks.erase(itr);
+              Py_DECREF(callback);
            }
         }
      }


### PR DESCRIPTION
* Describe `EVENT_COMMAND` as implemented
* Prevent crash in case `Py_BuildValue()` returns `NULL`
* Avoid changing callback refcount in constructor/destructor
  - Since items of `std::list` are stored by-value, and implicit copy constructor of `Callback` doesn't incref,  refcount of callback objects stored in the list is wrong
  - On top of that, destructor of `Callback` is called on exit, when the list is destroyed, but that happens only after `Py_Finalize()`, so it is already too late to decref (and decref on bogus `PyObject` can cause crash)
* Make it possible to use a method as a callback
* Handle log messages containing invalid characters 