### PR TITLE
Keep SOABI in extension filename

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,24 @@
-all: cec.so
-
 PYTHON?=python
 
 ARCH:=$(shell uname -m)
 SYS:=$(shell uname -s | tr '[:upper:]' '[:lower:]')
 PY_VER:=$(shell $(PYTHON) -c 'import sys; print("%d.%d"%(sys.version_info.major, sys.version_info.minor));')
 
+SOABI:=$(shell $(PYTHON) -c 'import sysconfig; print(sysconfig.get_config_var("SOABI") or "")')
+ifeq (,$(SOABI))
+	EXTENSION:=cec.so
+else
+	EXTENSION:=cec.$(SOABI).so
+endif
+
 BUILD_DIR:=build/lib.$(SYS)-$(ARCH)-$(PY_VER)
 
-cec.so: $(BUILD_DIR)/cec.so
+all: $(EXTENSION)
+
+$(EXTENSION): $(BUILD_DIR)/$(EXTENSION)
 	cp $< $@
 
-$(BUILD_DIR)/cec.so: cec.cpp setup.py device.h device.cpp
+$(BUILD_DIR)/$(EXTENSION): cec.cpp setup.py device.h device.cpp
 	$(PYTHON) setup.py build
 
 test: all
@@ -20,5 +27,5 @@ test: all
 
 clean:
 	rm -rf build
-	rm -f cec.so
+	rm -f $(EXTENSION)
 .PHONY: clean

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,6 @@ if "CFLAGS" in cfg_vars:
     cfg_vars["CFLAGS"] = cfg_vars["CFLAGS"].replace("-Wstrict-prototypes", "")
 if "OPT" in cfg_vars:
     cfg_vars["OPT"] = cfg_vars["OPT"].replace("-Wstrict-prototypes", "")
-# Do not append SOABI to extension filename
-if "EXT_SUFFIX" in cfg_vars:
-    cfg_vars["EXT_SUFFIX"] = ".so"
 
 python_cec = Extension('cec', sources = [ 'cec.cpp', 'device.cpp' ], 
                         include_dirs=['include'],


### PR DESCRIPTION
Removing SOABI is not such a good idea, because it could cause problems with module loading.

Keep SOABI in extension filename and modify Makefile to handle it properly.
