### PR TITLE
compat for libcec3 that lacks CEC_MAX_DATA_PACKET_SIZE

### DIFF
--- a/device.h
+++ b/device.h
@@ -39,3 +39,10 @@ struct Device {
 };
 
 PyTypeObject * DeviceTypeInit(CEC::ICECAdapter * adapter);
+
+/*
+ * Compat for libcec 3.x
+ */
+#if CEC_LIB_VERSION_MAJOR < 4
+  #define CEC_MAX_DATA_PACKET_SIZE (16 * 4)
+#endif


### PR DESCRIPTION
Compat for libcec3 that lacks CEC_MAX_DATA_PACKET_SIZE in cectypes.h but is needed by cec.cpp devices.cpp. This enables python-cec to be built on debian jesse (specifically raspbian 8).