### PR TITLE
Can not use int with PyArg_ParseTuple since python 3.10 (fix for #58)

### DIFF
--- a/cec.cpp
+++ b/cec.cpp
@@ -26,6 +26,7 @@
 // request the std format macros
 #define __STDC_FORMAT_MACROS
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <stdlib.h>
 #include <inttypes.h>
@@ -330,7 +331,7 @@ static PyObject * add_callback(PyObject * self, PyObject * args) {
 
 static PyObject * remove_callback(PyObject * self, PyObject * args) {
   PyObject * callback;
-  long int events = EVENT_ALL; // default to all events
+  Py_ssize_t events = EVENT_ALL; // default to all events
 
   if( PyArg_ParseTuple(args, "O|i:remove_callback", &callback, &events) ) {
      for( cb_list::iterator itr = callbacks.begin(); 
@@ -364,7 +365,7 @@ static PyObject * make_bound_method_args(PyObject * self, PyObject * args) {
    assert(self != NULL);
    Py_INCREF(self);
    PyTuple_SetItem(result, 0, self);
-   for( int i=0; i<count; i++ ) {
+   for( Py_ssize_t i=0; i<count; i++ ) {
       PyObject * arg = PyTuple_GetItem(args, i);
       if( arg == NULL ) {
          Py_DECREF(result);
@@ -425,7 +426,7 @@ static PyObject * transmit(PyObject * self, PyObject * args) {
    unsigned char destination;
    unsigned char opcode;
    const char * params = NULL;
-   int param_count = 0;
+   Py_ssize_t param_count = 0;
 
    if( PyArg_ParseTuple(args, "bb|s#b:transmit", &destination, &opcode,
          &params, &param_count, &initiator) ) {
@@ -456,7 +457,7 @@ static PyObject * transmit(PyObject * self, PyObject * args) {
       data.opcode = (cec_opcode)opcode;
       data.opcode_set = 1;
       if( params ) {
-         for( int i=0; i<param_count; i++ ) {
+         for( Py_ssize_t i=0; i<param_count; i++ ) {
             data.PushBack(((uint8_t *)params)[i]);
          }
       }

--- a/device.cpp
+++ b/device.cpp
@@ -191,7 +191,7 @@ static PyObject * Device_audio_input(Device * self, PyObject * args) {
 static PyObject * Device_transmit(Device * self, PyObject * args) {
    unsigned char opcode;
    const char * params = NULL;
-   int param_count = 0;
+   Py_ssize_t param_count = 0;
    if( PyArg_ParseTuple(args, "b|s#:transmit", &opcode,
          &params, &param_count) ) {
       if( param_count > CEC_MAX_DATA_PACKET_SIZE ) {
@@ -209,7 +209,7 @@ static PyObject * Device_transmit(Device * self, PyObject * args) {
       data.opcode = (cec_opcode)opcode;
       data.opcode_set = 1;
       if( params ) {
-         for( int i=0; i<param_count; i++ ) {
+         for( Py_ssize_t i=0; i<param_count; i++ ) {
             data.PushBack(((uint8_t *)params)[i]);
          }
       }

--- a/device.h
+++ b/device.h
@@ -22,6 +22,7 @@
  * Author: Austin Hendrix <namniart@gmail.com>
  */
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 #include <libcec/cec.h>


### PR DESCRIPTION
I have no idea what I'm doing (not a C guy), so please review this.
This compiles and works for me with Python 3.10. Tested with my TV, seems good. But C allows too much stuff, which I am not an expert of, so some segfaults could be hiding there. :shrug: 

More info on the issue: https://bugs.python.org/issue40943