### PR TITLE
Implemented cec.close()

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ adapters = cec.list_adapters() # may be called before init()
 cec.init() # use default adapter
 cec.init(adapter) # use a specific adapter
 
-cec.close()  # not implemented yet
+cec.close()  # close the current adapter
 
 cec.add_callback(handler, events)
 # the list of events is specified as a bitmask of the possible events:

--- a/cb_test.py
+++ b/cb_test.py
@@ -37,4 +37,7 @@ cec.volume_up()
 print("Volume Down")
 cec.volume_down()
 
+print("Closing")
+cec.close()
+
 print("SUCCESS!")

--- a/cec.cpp
+++ b/cec.cpp
@@ -217,11 +217,6 @@ static PyObject * list_adapters(PyObject * self, PyObject * args) {
    return result;
 }
 
-static void destoryAdapter() {
-   CECDestroy(CEC_adapter);
-   CEC_adapter = NULL;
-}
-
 static PyObject * init(PyObject * self, PyObject * args) {
    PyObject * result = NULL;
    const char * dev = NULL;
@@ -251,7 +246,8 @@ static PyObject * init(PyObject * self, PyObject * args) {
          result = Py_None;
       } else {
          Py_BEGIN_ALLOW_THREADS
-         destoryAdapter();
+         CECDestroy(CEC_adapter);
+         CEC_adapter = NULL;
          Py_END_ALLOW_THREADS
          char errstr[1024];
          snprintf(errstr, 1024, "CEC failed to open %s", dev);
@@ -267,7 +263,6 @@ static PyObject * close(PyObject * self, PyObject * args) {
    if( CEC_adapter != NULL ) {
       Py_BEGIN_ALLOW_THREADS
       CEC_adapter->Close();
-      destoryAdapter();
       Py_END_ALLOW_THREADS
    }
 

--- a/cec.cpp
+++ b/cec.cpp
@@ -676,6 +676,7 @@ PyObject * persist_config(PyObject * self, PyObject * args) {
 static PyMethodDef CecMethods[] = {
    {"list_adapters", list_adapters, METH_VARARGS, "List available adapters"},
    {"init", init, METH_VARARGS, "Open an adapter"},
+   {"close", close, METH_VARARGS, "Close an adapter"},
    {"list_devices", list_devices, METH_VARARGS, "List devices"},
    {"add_callback", add_callback, METH_VARARGS, "Add a callback"},
    {"remove_callback", remove_callback, METH_VARARGS, "Remove a callback"},

--- a/cec.cpp
+++ b/cec.cpp
@@ -217,6 +217,13 @@ static PyObject * list_adapters(PyObject * self, PyObject * args) {
    return result;
 }
 
+static void destoryAdapter() {
+   Py_BEGIN_ALLOW_THREADS
+   CECDestroy(CEC_adapter);
+   CEC_adapter = NULL;
+   Py_END_ALLOW_THREADS
+}
+
 static PyObject * init(PyObject * self, PyObject * args) {
    PyObject * result = NULL;
    const char * dev = NULL;
@@ -245,11 +252,7 @@ static PyObject * init(PyObject * self, PyObject * args) {
          Py_INCREF(Py_None);
          result = Py_None;
       } else {
-         Py_BEGIN_ALLOW_THREADS
-         CECDestroy(CEC_adapter);
-         CEC_adapter = NULL;
-         Py_END_ALLOW_THREADS
-
+         destoryAdapter();
          char errstr[1024];
          snprintf(errstr, 1024, "CEC failed to open %s", dev);
          PyErr_SetString(PyExc_IOError, errstr);
@@ -257,6 +260,18 @@ static PyObject * init(PyObject * self, PyObject * args) {
    }
 
    return result;
+}
+
+static PyObject * close(PyObject * self, PyObject * args) {
+
+   if( PyArg_ParseTuple(args, "") == 0 && CEC_adapter == NULL ) {
+      Py_BEGIN_ALLOW_THREADS
+      CEC_adapter->Close();
+      destoryAdapter();
+      Py_END_ALLOW_THREADS
+   }
+
+   return NULL;
 }
 
 static PyObject * list_devices(PyObject * self, PyObject * args) {

--- a/cec.cpp
+++ b/cec.cpp
@@ -271,7 +271,8 @@ static PyObject * close(PyObject * self, PyObject * args) {
       Py_END_ALLOW_THREADS
    }
 
-   return NULL;
+   Py_INCREF(Py_None)
+   return Py_None;
 }
 
 static PyObject * list_devices(PyObject * self, PyObject * args) {

--- a/cec.cpp
+++ b/cec.cpp
@@ -271,7 +271,7 @@ static PyObject * close(PyObject * self, PyObject * args) {
       Py_END_ALLOW_THREADS
    }
 
-   Py_INCREF(Py_None)
+   Py_INCREF(Py_None);
    return Py_None;
 }
 

--- a/cec.cpp
+++ b/cec.cpp
@@ -218,10 +218,8 @@ static PyObject * list_adapters(PyObject * self, PyObject * args) {
 }
 
 static void destoryAdapter() {
-   Py_BEGIN_ALLOW_THREADS
    CECDestroy(CEC_adapter);
    CEC_adapter = NULL;
-   Py_END_ALLOW_THREADS
 }
 
 static PyObject * init(PyObject * self, PyObject * args) {
@@ -252,7 +250,9 @@ static PyObject * init(PyObject * self, PyObject * args) {
          Py_INCREF(Py_None);
          result = Py_None;
       } else {
+         Py_BEGIN_ALLOW_THREADS
          destoryAdapter();
+         Py_END_ALLOW_THREADS
          char errstr[1024];
          snprintf(errstr, 1024, "CEC failed to open %s", dev);
          PyErr_SetString(PyExc_IOError, errstr);
@@ -264,7 +264,7 @@ static PyObject * init(PyObject * self, PyObject * args) {
 
 static PyObject * close(PyObject * self, PyObject * args) {
 
-   if( PyArg_ParseTuple(args, "") == 0 && CEC_adapter == NULL ) {
+   if( CEC_adapter != NULL ) {
       Py_BEGIN_ALLOW_THREADS
       CEC_adapter->Close();
       destoryAdapter();
@@ -677,7 +677,7 @@ PyObject * persist_config(PyObject * self, PyObject * args) {
 static PyMethodDef CecMethods[] = {
    {"list_adapters", list_adapters, METH_VARARGS, "List available adapters"},
    {"init", init, METH_VARARGS, "Open an adapter"},
-   {"close", close, METH_VARARGS, "Close an adapter"},
+   {"close", close, METH_NOARGS, "Close an adapter"},
    {"list_devices", list_devices, METH_VARARGS, "List devices"},
    {"add_callback", add_callback, METH_VARARGS, "Add a callback"},
    {"remove_callback", remove_callback, METH_VARARGS, "Remove a callback"},


### PR DESCRIPTION
I found that killing the process or finishing the script locks out this library from further use in other scripts, as well as the `cec-utils` command line utility.